### PR TITLE
Use tides

### DIFF
--- a/client/src/useTides.js
+++ b/client/src/useTides.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 function useTides({ startDate, endDate }) {
-  const [tideInfo, setTideInfo] = useState(null);
+  const [tideInfo, setTideInfo] = useState({ predictions: [] });
   const tideBaseURL =
     'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?product=predictions&datum=MLLW&station=9446583&time_zone=lst_ldt&units=english&interval=hilo&format=json&application=NOS.COOPS.TAC.TidePred';
 
@@ -35,7 +35,34 @@ function useTides({ startDate, endDate }) {
     fetchTideData();
   }, []);
 
-  return tideInfo;
+  console.log(tideInfo);
+
+  /*   const tidiedTideInfo = {
+    HighTide: tideInfo.predictions.reduce((previousTidePrediction, currentTidePrediction) => {
+      console.log(currentTidePrediction.v);
+      parseFloat(currentTidePrediction['v']) > parseFloat(previousTidePrediction['v'])
+        ? currentTidePrediction
+        : previousTidePrediction;
+    }, tideInfo.predictions[0]),
+    LowTide: tideInfo.predictions.reduce((previousTidePrediction, currentTidePrediction) => {
+      parseFloat(currentTidePrediction['v']) < parseFloat(previousTidePrediction['v'])
+        ? currentTidePrediction
+        : previousTidePrediction;
+    }, tideInfo.predictions[0])
+  }; */
+
+  const tidiedTideInfo = {
+    lowTide: tideInfo.predictions.sort(
+      (prevTidePrediction, nextTidePrediction) =>
+        parseFloat(prevTidePrediction.v) - parseFloat(nextTidePrediction.v)
+    )[0],
+    highTide: tideInfo.predictions.sort(
+      (prevTidePrediction, nextTidePrediction) =>
+        parseFloat(nextTidePrediction.v) - parseFloat(prevTidePrediction.v)
+    )[0]
+  };
+
+  return tidiedTideInfo;
 }
 
 export default useTides;

--- a/client/src/useTides.js
+++ b/client/src/useTides.js
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 
 function useTides({ startDate, endDate }) {
   const [tideInfo, setTideInfo] = useState({ predictions: [] });
+  let dateOrganizedTideArray = [];
+  let tidiedTideInfo = [];
   const tideBaseURL =
     'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?product=predictions&datum=MLLW&station=9446583&time_zone=lst_ldt&units=english&interval=hilo&format=json&application=NOS.COOPS.TAC.TidePred';
 
@@ -35,16 +37,29 @@ function useTides({ startDate, endDate }) {
     fetchTideData();
   }, []);
 
-  const tidiedTideInfo = {
-    lowTide: tideInfo.predictions.sort(
-      (prevTidePrediction, nextTidePrediction) =>
-        parseFloat(prevTidePrediction.v) - parseFloat(nextTidePrediction.v)
-    )[0],
-    highTide: tideInfo.predictions.sort(
-      (prevTidePrediction, nextTidePrediction) =>
-        parseFloat(nextTidePrediction.v) - parseFloat(prevTidePrediction.v)
-    )[0]
-  };
+  for (let i = 0; i < tideInfo.predictions.length - 1; i++) {
+    if (tideInfo.predictions[i].t.slice(0, 10) != tideInfo.predictions[i + 1].t.slice(0, 10)) {
+      dateOrganizedTideArray.push(
+        tideInfo.predictions.filter(
+          (tidePrediction) =>
+            tideInfo.predictions[i].t.slice(0, 10) == tidePrediction.t.slice(0, 10)
+        )
+      );
+    }
+  }
+
+  dateOrganizedTideArray.map((tidePredicitions) => {
+    tidiedTideInfo.push({
+      lowTide: tidePredicitions.sort(
+        (prevTidePrediction, nextTidePrediction) =>
+          parseFloat(prevTidePrediction.v) - parseFloat(nextTidePrediction.v)
+      )[0],
+      highTide: tidePredicitions.sort(
+        (prevTidePrediction, nextTidePrediction) =>
+          parseFloat(nextTidePrediction.v) - parseFloat(prevTidePrediction.v)
+      )[0]
+    });
+  });
 
   return tidiedTideInfo;
 }

--- a/client/src/useTides.js
+++ b/client/src/useTides.js
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+
+function useTides({ startDate, endDate }) {
+  const [tideInfo, setTideInfo] = useState(null);
+  const tideBaseURL =
+    'https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?product=predictions&datum=MLLW&station=9446583&time_zone=lst_ldt&units=english&interval=hilo&format=json&application=NOS.COOPS.TAC.TidePred';
+
+  useEffect(() => {
+    const fetchTideData = async () => {
+      try {
+        await fetch(tideBaseURL + `&begin_date=${startDate}&end_date=${endDate}`, {
+          headers: {
+            accept: '*/*',
+            'accept-language': 'en-US,en;q=0.9',
+            'sec-ch-ua': '"Chromium";v="104", " Not A;Brand";v="99", "Google Chrome";v="104"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'cross-site'
+          },
+          referrerPolicy: 'strict-origin-when-cross-origin',
+          body: null,
+          method: 'GET',
+          mode: 'cors',
+          credentials: 'omit'
+        })
+          .then((response) => response.json())
+          .then((responseJson) => setTideInfo(responseJson));
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchTideData();
+  }, []);
+
+  return tideInfo;
+}
+
+export default useTides;

--- a/client/src/useTides.js
+++ b/client/src/useTides.js
@@ -35,22 +35,6 @@ function useTides({ startDate, endDate }) {
     fetchTideData();
   }, []);
 
-  console.log(tideInfo);
-
-  /*   const tidiedTideInfo = {
-    HighTide: tideInfo.predictions.reduce((previousTidePrediction, currentTidePrediction) => {
-      console.log(currentTidePrediction.v);
-      parseFloat(currentTidePrediction['v']) > parseFloat(previousTidePrediction['v'])
-        ? currentTidePrediction
-        : previousTidePrediction;
-    }, tideInfo.predictions[0]),
-    LowTide: tideInfo.predictions.reduce((previousTidePrediction, currentTidePrediction) => {
-      parseFloat(currentTidePrediction['v']) < parseFloat(previousTidePrediction['v'])
-        ? currentTidePrediction
-        : previousTidePrediction;
-    }, tideInfo.predictions[0])
-  }; */
-
   const tidiedTideInfo = {
     lowTide: tideInfo.predictions.sort(
       (prevTidePrediction, nextTidePrediction) =>


### PR DESCRIPTION
introduces a new useTides custom hook for consuming tide data to appear on the calendar. 

Ultimately I had to go with making one large request for the data rather than what I'd like which would be paging and gathering that info as the user goes through the months, but like the bookings I suppose that can come later.